### PR TITLE
Add containing method to StylistIdentifier

### DIFF
--- a/Example/Tests/StylistIdentifierTests.swift
+++ b/Example/Tests/StylistIdentifierTests.swift
@@ -95,29 +95,6 @@ final class StylistIdentifierTests: XCTestCase {
         XCTAssertTrue(StylistIdentifier("*/*/*/identifier").matches("section/*/identifier"))
     }
 
-    func testStylistIdentifier_concat() {
-        let id1 = StylistIdentifier("element/section/identifier")
-        let id2 = StylistIdentifier("screen/section")
-
-        XCTAssertEqual(id1.within(id2), "screen/section/element/section/identifier")
-    }
-
-    func testStylistIdentifier_concatWithEmptyComponents() {
-        let id1 = StylistIdentifier("element/*/identifier")
-        let id2 = StylistIdentifier("screen/section")
-
-        XCTAssertEqual(id1.within(id2), "screen/section/element/*/identifier")
-    }
-
-    func testStylistIdentifier_concatEmptyIdentifier() {
-        let empty = StylistIdentifier()
-
-        let i = StylistIdentifier("a/b/c")
-        XCTAssertEqual(i.within(empty), i)
-
-        XCTAssertEqual(empty.within(empty), empty)
-    }
-
     func testStylistIdentifier_comparable() {
         let i1 = StylistIdentifier("a/b/c")
         let i2 = StylistIdentifier("*/*/c")
@@ -150,7 +127,33 @@ final class StylistIdentifierTests: XCTestCase {
     }
 
     func testStylistIdentifier_within() {
-        XCTAssertEqual("atom".within("element").within("section").description, "section/element/atom")
+        let id1 = StylistIdentifier("element/section/identifier")
+        let id2 = StylistIdentifier("screen/section")
+
+        XCTAssertEqual(id1.within(id2), "screen/section/element/section/identifier")
+    }
+
+    func testStylistIdentifier_containing() {
+        let id1 = StylistIdentifier("element/section/identifier")
+        let id2 = StylistIdentifier("screen/section")
+
+        XCTAssertEqual(id2.containing(id1), "screen/section/element/section/identifier")
+    }
+
+    func testStylistIdentifier_withinWithEmptyComponents() {
+        let id1 = StylistIdentifier("element/*/identifier")
+        let id2 = StylistIdentifier("screen/section")
+
+        XCTAssertEqual(id1.within(id2), "screen/section/element/*/identifier")
+    }
+
+    func testStylistIdentifier_withinEmptyIdentifier() {
+        let empty = StylistIdentifier()
+
+        let i = StylistIdentifier("a/b/c")
+        XCTAssertEqual(i.within(empty), i)
+
+        XCTAssertEqual(empty.within(empty), empty)
     }
 
     func testStylistIdentifier_withinNil() {

--- a/StylableSwiftUI/Classes/StylistIdentifier.swift
+++ b/StylableSwiftUI/Classes/StylistIdentifier.swift
@@ -260,7 +260,7 @@ extension StylistIdentifier {
 
     /// Create an new identifier where the passed in identifier is inside `self`
     ///
-    /// i.e. `"button".contains("close") == 'button/close'`
+    /// i.e. `"button".containing("close") == 'button/close'`
     ///
     public func containing(_ identifier: StylistIdentifier?) -> StylistIdentifier {
         guard let identifier = identifier else { return self }

--- a/StylableSwiftUI/Classes/StylistIdentifier.swift
+++ b/StylableSwiftUI/Classes/StylistIdentifier.swift
@@ -248,7 +248,7 @@ extension StylistIdentifier {
 
     /// Create an identifier representing `self` inside `identifier`
     ///
-    /// i.e. `"close".within("button") == 'close/button'`
+    /// i.e. `"close".within("button") == 'button/close'`
     ///
     public func within(_ identifier: StylistIdentifier?) -> StylistIdentifier {
         guard let identifier = identifier else { return self }
@@ -257,15 +257,31 @@ extension StylistIdentifier {
         components.append(contentsOf: identifier.components)
         return StylistIdentifier(components: components)
     }
+
+    /// Create an new identifier where the passed in identifier is inside `self`
+    ///
+    /// i.e. `"button".contains("close") == 'button/close'`
+    ///
+    public func containing(_ identifier: StylistIdentifier?) -> StylistIdentifier {
+        guard let identifier = identifier else { return self }
+        return identifier.within(self)
+    }
 }
 
 extension String {
 
-    /// Asthetic wrapper around `StylistIdentifier.within(_:)`
+    /// Aesthetic wrapper around `StylistIdentifier.within(_:)`
     ///
     /// Allows code like `"close".within("button")` to compile and return a valid `StylistIdentifier`
     public func within(_ identifier: StylistIdentifier?) -> StylistIdentifier {
-        return StylistIdentifier(self).within(identifier)
+        StylistIdentifier(self).within(identifier)
+    }
+
+    /// Aesthetic wrapper around `StylistIdentifier.containing(_:)`
+    ///
+    /// Allows code like `"button".containing("close")` to compile and return a valid `StylistIdentifier`
+    public func containing(_ identifier: StylistIdentifier?) -> StylistIdentifier {
+        StylistIdentifier(self).containing(identifier)
     }
 }
 

--- a/StylableSwiftUI/Classes/StylistIdentifier.swift
+++ b/StylableSwiftUI/Classes/StylistIdentifier.swift
@@ -270,18 +270,11 @@ extension StylistIdentifier {
 
 extension String {
 
-    /// Aesthetic wrapper around `StylistIdentifier.within(_:)`
+    /// Asthetic wrapper around `StylistIdentifier.within(_:)`
     ///
     /// Allows code like `"close".within("button")` to compile and return a valid `StylistIdentifier`
     public func within(_ identifier: StylistIdentifier?) -> StylistIdentifier {
-        StylistIdentifier(self).within(identifier)
-    }
-
-    /// Aesthetic wrapper around `StylistIdentifier.containing(_:)`
-    ///
-    /// Allows code like `"button".containing("close")` to compile and return a valid `StylistIdentifier`
-    public func containing(_ identifier: StylistIdentifier?) -> StylistIdentifier {
-        StylistIdentifier(self).containing(identifier)
+        return StylistIdentifier(self).within(identifier)
     }
 }
 


### PR DESCRIPTION
Mirror of 'within'.

@kerrmarin This is interesting if we don't want to pollute the String methods - we should either have within and contains on string, or neither. I'm good either way, but I kind of agree its a bit funky just sticking things directly onto String.
