### PR TITLE
Update podspec version

### DIFF
--- a/StylableSwiftUI.podspec
+++ b/StylableSwiftUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'StylableSwiftUI'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'StylableSwiftUI - Style SwifTUI apps and libraries'
   s.description      = <<-DESC
 Easily tag a SwiftUI library so it can be styled by multiple apps.


### PR DESCRIPTION
😄 

```bash
stylable-swiftui|release-1.0.1 ⇒ pod lib lint

 -> StylableSwiftUI (1.0.1)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Building targets in parallel
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - NOTE  | [iOS] xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'StylableSwiftUI' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Pods-App' from project 'Pods')
    - NOTE  | [iOS] xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'App' from project 'App')

StylableSwiftUI passed validation.
```